### PR TITLE
A good starting point

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,27 +1,28 @@
-Want to contribute? Great! First, read this page (including the small print at the end).
+# How to Contribute
 
-### Before you contribute
-Before we can use your code, you must sign the
-[Google Individual Contributor License Agreement]
-(https://cla.developers.google.com/about/google-individual)
-(CLA), which you can do online. The CLA is necessary mainly because you own the
-copyright to your changes, even after your contribution becomes part of our
-codebase, so we need your permission to use and distribute your code. We also
-need to be sure of various other things—for instance that you'll tell us if you
-know that your code infringes on other people's patents. You don't have to sign
-the CLA until after you've submitted your code for review and a member has
-approved it, but you must do it before we can put your code into our codebase.
-Before you start working on a larger contribution, you should get in touch with
-us first through the issue tracker with your idea so that we can help out and
-possibly guide you. Coordinating up front makes it much easier to avoid
-frustration later on.
+We'd love to accept your patches and contributions to this project. There are
+just a few small guidelines you need to follow.
 
-### Code reviews
+## Contributor License Agreement
+
+Contributions to this project must be accompanied by a Contributor License
+Agreement. You (or your employer) retain the copyright to your contribution;
+this simply gives us permission to use and redistribute your contributions as
+part of the project. Head over to <https://cla.developers.google.com/> to see
+your current agreements on file or to sign a new one.
+
+You generally only need to submit a CLA once, so if you've already submitted one
+(even if it was for a different project), you probably don't need to do it
+again.
+
+## Code reviews
+
 All submissions, including submissions by project members, require review. We
-use Github pull requests for this purpose.
+use GitHub pull requests for this purpose. Consult
+[GitHub Help](https://help.github.com/articles/about-pull-requests/) for more
+information on using pull requests.
 
-### The small print
-Contributions made by corporations are covered by a different agreement than
-the one above, the
-[Software Grant and Corporate Contributor License Agreement]
-(https://cla.developers.google.com/about/google-corporate).
+## Community Guidelines
+
+This project follows [Google's Open Source Community
+Guidelines](https://opensource.google.com/conduct/).

--- a/LICENSE
+++ b/LICENSE
@@ -1,3 +1,4 @@
+
                                  Apache License
                            Version 2.0, January 2004
                         http://www.apache.org/licenses/
@@ -186,7 +187,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2015 Google Inc
+   Copyright [yyyy] [name of copyright owner]
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,56 @@
+# Codelab Custom Elements
+
+The next generation of the codelab elements without any framework or library
+dependencies, only the [Custom Elements](https://html.spec.whatwg.org/multipage/custom-elements.html)
+standard spec.
+
+## Dev environment
+
+All you need is [bazel](https://docs.bazel.build/versions/master/install.html).
+
+After bazel is installed, try executing the following:
+
+    bazel test --test_output=all //demo:hello_test
+
+It will take some time at the first run because bazel will download and compile
+all dependencies needed to work with the code and run tests. This includes
+Google Closure library and compiler, Go language and browsers to run local JS
+tests on.
+
+### Building
+
+Check out a demo HelloElement target. To build the element, execute the following:
+
+    bazel build //demo:hello_bin
+
+It should output something like this:
+
+    INFO: Analysed target //demo:hello_bin (0 packages loaded).
+    INFO: Found 1 target...
+    Target //demo:hello_bin up-to-date:
+      bazel-bin/demo/hello_bin.js
+      bazel-bin/demo/hello_bin.js.map
+    INFO: Elapsed time: 0.716s, Critical Path: 0.03s
+    INFO: Build completed successfully, 1 total action
+
+### Testing
+
+All elements should have their test targets.
+As a starting point, check out HelloElement tests:
+
+    bazel test --test_output=errors //demo:hello_test
+
+You should see something like this:
+
+    INFO: Elapsed time: 5.394s, Critical Path: 4.60s
+    INFO: Build completed successfully, 2 total actions
+    //demo:hello_test_chromium-local                      PASSED in 4.6s
+
+When things go wrong, it is usually easier to inspect and analyze output
+with debug enabled:
+
+    bazel test -s --verbose_failures --test_output=all --test_arg=-debug demo/hello_test
+
+## Notes
+
+This is not an official Google product.

--- a/README.md
+++ b/README.md
@@ -51,6 +51,14 @@ with debug enabled:
 
     bazel test -s --verbose_failures --test_output=all --test_arg=-debug demo/hello_test
 
+### Manual inspection from a browser
+
+To browse things around manually with a real browser, execute the following:
+
+    bazel run //tools:server
+
+and navigate to http://localhost:8080.
+
 ## Notes
 
 This is not an official Google product.

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1,25 +1,63 @@
+workspace(name = "googlecodelabs_custom_elements")
+
+# Required by io_bazel_rules_webtesting.
+skylib_ver = "f9b0ff1dd3d119d19b9cacbbc425a9e61759f1f5"
+http_archive(
+    name = "bazel_skylib",
+    sha256 = "ce27a2007deda8a1de65df9de3d4cd93a5360ead43c5ff3017ae6b3a2abe485e",
+    strip_prefix = "bazel-skylib-{v}".format(v=skylib_ver),
+    urls = [
+        "https://github.com/bazelbuild/bazel-skylib/archive/{v}.tar.gz".format(v=skylib_ver),
+    ],
+)
+
+rules_closure_ver = "f4d0633f14570313b94822223039ebda0f398102"
 http_archive(
     name = "io_bazel_rules_closure",
     sha256 = "8e615c1c282ba680e667549e242cfcc0643846ee7c0c8c816bee077b3edda567",
-    url = "https://github.com/bazelbuild/rules_closure/archive/f4d0633f14570313b94822223039ebda0f398102.zip",
-    strip_prefix = "rules_closure-f4d0633f14570313b94822223039ebda0f398102",
+    strip_prefix = "rules_closure-{v}".format(v=rules_closure_ver),
+    url = "https://github.com/bazelbuild/rules_closure/archive/{v}.zip".format(v=rules_closure_ver),
 )
 load("@io_bazel_rules_closure//closure:defs.bzl", "closure_repositories")
 closure_repositories()
 
 http_archive(
     name = "io_bazel_rules_go",
-    url = "https://github.com/bazelbuild/rules_go/releases/download/0.10.0/rules_go-0.10.0.tar.gz",
     sha256 = "53c8222c6eab05dd49c40184c361493705d4234e60c42c4cd13ab4898da4c6be",
+    url = "https://github.com/bazelbuild/rules_go/releases/download/0.10.0/rules_go-0.10.0.tar.gz",
 )
 load("@io_bazel_rules_go//go:def.bzl", "go_rules_dependencies", "go_register_toolchains")
 go_rules_dependencies()
 go_register_toolchains()
 
+rules_webtesting_ver = "936c760cff973a63031be0d0518b40a228e224e3"
+http_archive(
+    name = "io_bazel_rules_webtesting",
+    sha256 = "797b75e792a34728a6a3846c7c3d3ad669f12cd8490b888cc969bad93d236b1b",
+    strip_prefix = "rules_webtesting-{v}".format(v=rules_webtesting_ver),
+    url = "https://github.com/bazelbuild/rules_webtesting/archive/{v}.zip".format(v=rules_webtesting_ver),
+)
+load(
+    "@io_bazel_rules_webtesting//web:repositories.bzl",
+    "browser_repositories",
+    "web_test_repositories",
+)
+web_test_repositories()
+browser_repositories(chromium = True)
+
 new_http_archive(
     name = "polyfill",
-    url = "https://github.com/webcomponents/custom-elements/archive/v1.0.8.zip",
+    build_file = "third_party/BUILD.polyfill",
     sha256 = "9606cdeacbb67f21fb495a4b0a0e5ea6a137fc453945907822e1b930e77124d4",
     strip_prefix = "custom-elements-1.0.8",
-    build_file = "BUILD.polyfill",
+    url = "https://github.com/webcomponents/custom-elements/archive/v1.0.8.zip",
+)
+
+es6shim_ver = "8d7aec1403751686dbbd3c4fa13a7bb584a75bf3"
+new_http_archive(
+    name = "es6shim",
+    build_file = "third_party/BUILD.es6shim",
+    sha256 = "108e7de0edc041a36561e1518fc5d87569f5cfd5449977658cc9b1e2c84743b3",
+    strip_prefix = "es6-shim-{v}".format(v=es6shim_ver),
+    url = "https://github.com/es-shims/es6-shim/archive/{v}.zip".format(v=es6shim_ver),
 )

--- a/demo/BUILD
+++ b/demo/BUILD
@@ -1,7 +1,10 @@
-load("@io_bazel_rules_closure//closure:defs.bzl", "closure_js_binary", "closure_js_library", "closure_js_test")
+load("//tools:defs.bzl",
+     "closure_js_library", "closure_js_binary", "closure_js_test")
 
 package(default_visibility = ["//visibility:public"])
 
+# All static artifacts needed for various demo files.
+# Used by //tools:server target.
 filegroup(
     name = "demo_files",
     srcs = glob([
@@ -10,39 +13,45 @@ filegroup(
     ]),
 )
 
+# A playground HelloElement.
 closure_js_library(
     name = "hello_lib",
     srcs = ["hello.js"],
     convention = "GOOGLE",
 )
 
+# Compiled version of HelloElement, suitable for distribution.
 closure_js_binary(
     name = "hello_bin",
-    compilation_level = "ADVANCED",
-    defs = [
-        "--assume_function_wrapper",
-        "--new_type_inf",
-        "--rewrite_polyfills=false",
-    ],
-    dependency_mode = "STRICT",
     entry_points = ["googlecodelabs.HelloElement"],
-    language = "ECMASCRIPT5_STRICT",
-    output_wrapper = "(function(){%output%}).call(this);",
     deps = [":hello_lib"],
 )
 
+# A few tests for HelloElement.
+# The following closure_js_test expands into something like this:
+#
+#    js_test(
+#        name = "hello_test",
+#        srcs = ["hello_test.js"],
+#        browsers = [
+#            # For experimental purposes only. Eventually you should
+#            # create your own browser definitions.
+#            "@io_bazel_rules_webtesting//browsers:chromium-local",
+#        ],
+#        data = ["@polyfill//:custom_elements"],
+#        entry_points = ["googlecodelabs.hello_test"],
+#        suppress = ["JSC_EXTRA_REQUIRE_WARNING"],
+#        deps = [
+#            ":hello_lib",
+#            "@io_bazel_rules_closure//closure/library:testing",
+#        ],
+#    )
+#
+# Additionally, a gen_hello_test.html file is generated,
+# declaring the hello_test_bin.js script source.
 closure_js_test(
     name = "hello_test",
     srcs = ["hello_test.js"],
-    data = [
-        "@polyfill//:custom_elements",
-        "@polyfill//:native_shim",
-    ],
     entry_points = ["googlecodelabs.hello_test"],
-    html = "hello_test.html",
-    suppress = ["JSC_EXTRA_REQUIRE_WARNING"],
-    deps = [
-        ":hello_lib",
-        "@io_bazel_rules_closure//closure/library:testing",
-    ],
+    deps = [":hello_lib"],
 )

--- a/demo/hello_test.js
+++ b/demo/hello_test.js
@@ -23,9 +23,16 @@ goog.require('goog.testing.asserts');
 goog.require('goog.testing.jsunit');
 
 testSuite({
-  testHello() {
+  testHelloEquals() {
+    const x = 6;
+    assertEquals(6, x);
+  },
+
+  testHelloUpgraded() {
     const div = document.createElement('div');
     div.innerHTML = "<hello-element>static</hello-element>";
     document.body.appendChild(div);
-  }
+    let text = div.textContent;
+    assert(`"${text}" does not end with 'upgraded!'`, text.endsWith("upgraded!"));
+  },
 });

--- a/third_party/BUILD.es6shim
+++ b/third_party/BUILD.es6shim
@@ -1,0 +1,11 @@
+package(default_visibility = ["//visibility:public"])
+
+filegroup(
+    name = "es6all",
+    srcs = [
+        "es6-sham.min.js",
+        "es6-sham.map",
+        "es6-shim.min.js",
+        "es6-shim.map",
+    ]
+)

--- a/third_party/BUILD.polyfill
+++ b/third_party/BUILD.polyfill
@@ -4,7 +4,7 @@ filegroup(
     name = "custom_elements",
     srcs = [
         "custom-elements.min.js",
-	"custom-elements.min.js.map",
+        "custom-elements.min.js.map",
     ]
 )
 

--- a/tools/BUILD
+++ b/tools/BUILD
@@ -1,11 +1,34 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_binary")
 
+# The gen_test_html.template is used by js_test rule.
+# See defs.bzl for details.
+exports_files(["gen_test_html.template"])
+
+# The JS tests runner.
+# See defs.bzl for details.
+go_binary(
+    name = "webtest",
+    testonly = 1,
+    srcs = ["webtest.go"],
+    visibility = ["//:__subpackages__"],
+    deps = [
+        "@com_github_tebeka_selenium//:go_default_library",
+        "@io_bazel_rules_webtesting//go/webtest:go_default_library",
+    ],
+)
+
+# A simple static file server. Handy for running tests manually or inspecting
+# content from a browser.
+# Execute "bazel run //tools:server" from command line
+# and open http://localhost:8080 in a browser.
 go_binary(
     name = "server",
+    testonly = 1,
     srcs = ["server.go"],
     data = [
         "//demo:demo_files",
         "//demo:hello_bin",
+        "//demo:hello_test",
         "@polyfill//:custom_elements",
         "@polyfill//:native_shim",
     ],

--- a/tools/defs.bzl
+++ b/tools/defs.bzl
@@ -1,0 +1,192 @@
+# Copyright 2018 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Repo's bazel rules and macros."""
+
+load("@io_bazel_rules_closure//closure:defs.bzl",
+     _closure_js_binary_alias="closure_js_binary")
+load("@io_bazel_rules_closure//closure:defs.bzl",
+     _closure_js_library_alias="closure_js_library")
+load("@io_bazel_rules_webtesting//web:web.bzl", "web_test_suite")
+
+def closure_js_library(**kwargs):
+  """Invokes actual closure_js_library with defaults suitable
+  for non-test JS source files.
+  """
+  kwargs.setdefault("convention", "GOOGLE")
+  _closure_js_library_alias(**kwargs)
+
+def closure_js_binary(**kwargs):
+  """Invokes actual closure_js_binary with defaults suitable
+  for non-test JS files compilation.
+  """
+  kwargs.setdefault("compilation_level", "ADVANCED")
+  kwargs.setdefault("dependency_mode", "STRICT")
+  kwargs.setdefault("language", "ECMASCRIPT5_STRICT")
+  kwargs.setdefault("output_wrapper", "(function(){%output%}).call(this);")
+  kwargs.setdefault("defs", [
+      "--assume_function_wrapper",
+      "--new_type_inf",
+      "--rewrite_polyfills=false",
+  ])
+  _closure_js_binary_alias(**kwargs)
+
+def _gen_test_html_impl(ctx):
+  """Implementation of the gen_test_html rule."""
+  ctx.actions.expand_template(
+      template=ctx.file._template,
+      output=ctx.outputs.html_file,
+      substitutions={
+          "{{TEST_FILE_JS}}": ctx.attr.test_file_js
+      })
+  runfiles = ctx.runfiles(files=[ctx.outputs.html_file], collect_default=True)
+  return [DefaultInfo(runfiles=runfiles)]
+
+# A rule used by js_test to generate default test.html file
+# suitable for running Closure-based JS tests.
+# The test_file_js argument specifies the name of the JS file containing tests,
+# typically created with closure_js_binary.
+# The output is created from gen_test_html.template file.
+gen_test_html = rule(
+  implementation=_gen_test_html_impl,
+  attrs={
+        "test_file_js": attr.string(mandatory=True),
+        "_template": attr.label(default=Label("//tools:gen_test_html.template"),
+                                allow_files=True, single_file=True),
+  },
+  outputs={"html_file": "%{name}.html"},
+)
+
+def js_test(name,
+            srcs,
+            browsers,
+            data=None,
+            deps=None,
+            compilation_level=None,
+            css=None,
+            entry_points=None,
+            html=None,
+            suppress=None,
+            visibility=None,
+            **kwargs):
+  """A lower level macro which creates JS tests suite.
+
+  It creates three targets: <name>_lib closure_js_library,
+  <name>_bin closure_js_binary with the former as a dependencies,
+  and <name> web_test_suite with the <name>_bin in its data dependencies.
+  All targets have testonly attribute set to True.
+
+  For more details about closure_js_library and closure_js_binary,
+  see https://github.com/bazelbuild/rules_closure.
+
+  Args:
+    name: The name of the test target.
+    srcs: A list of test source files with _test.js suffix.
+    browsers: A list of browsers to run on. See rules_webtesting
+      for list of supported browsers: https://goo.gl/VVH8tP.
+    data: A list of data dependencies passed to closure_js_library.
+    deps: list of code dependencies passed to closure_js_library.
+    compilation_level: Closure compiler compilation level.
+    css: A CSS class renaming target passed to closure_js_binary.
+      It must point to a closure_css_binary rule.
+    entry_points: List of unreferenced namespaces which should not
+      be pruned by the compiler. See //demo:hello_test
+      for a usage example.
+    html: An HTML file which declares the generated closure_js_binary
+      target it its <script src="..."> sources.
+      If not specified, a default is generated using gen_test_html
+      with gen_<name> target.
+    suppress: List of codes the linter should ignore,
+      passed to the generated closure_js_library target.
+    visibility: Target visibility.
+    kwargs: Additional arguments, passed to the web_test_suite target.
+  """
+  if not srcs:
+    fail("js_test rules can not have an empty 'srcs' list")
+  for src in srcs:
+    if not src.endswith('_test.js'):
+      fail("js_test srcs must be files ending with _test.js")
+
+  _closure_js_library_alias(
+      name = "%s_lib" % name,
+      srcs = srcs,
+      data = data,
+      deps = deps,
+      suppress = suppress,
+      visibility = visibility,
+      testonly = True,
+  )
+
+  _closure_js_binary_alias(
+      name = "%s_bin" % name,
+      deps = [":%s_lib" % name],
+      entry_points = entry_points,
+      css = css,
+      debug = True,
+      defs = [
+          "--new_type_inf",
+          "--rewrite_polyfills=false",
+          "--jscomp_off=analyzerChecks",
+      ],
+      language = "ECMASCRIPT_2015",
+      dependency_mode = "LOOSE",
+      formatting = "PRETTY_PRINT",
+      visibility = visibility,
+      testonly = True,
+  )
+
+  if not html:
+      gen_test_html(
+          name="gen_%s" % name,
+          test_file_js="%s_bin.js" % name
+      )
+      html = "gen_%s" % name
+
+  web_test_suite(
+      name = name,
+      data = [":%s_bin" % name, html],
+      test = "//tools:webtest",
+      args = ["--test_url", "$(location %s)" % html],
+      browsers = browsers,
+      visibility = visibility,
+      **kwargs
+  )
+
+def closure_js_test(**kwargs):
+  """A handy higher level macro built on top of js_test.
+
+  It sets useful defaults suitable for running all JS tests in this repo:
+  - adds closure/library:testing to the deps
+  - adds custom elements polyfill to the data
+  - suppresses linter's known false positives
+  - sets default list of browsers to run tests on
+  """
+  deps = kwargs.pop("deps", [])
+  deps.append("@io_bazel_rules_closure//closure/library:testing")
+
+  data = kwargs.pop("data", [])
+  data.append("@polyfill//:custom_elements")
+
+  suppress = kwargs.pop("suppress", [])
+  suppress.append("JSC_EXTRA_REQUIRE_WARNING")
+
+  kwargs.update(dict(deps=deps, data=data, suppress=suppress))
+  kwargs.setdefault("browsers", [
+      # For experimental purposes only. Eventually you should
+      # create your own browser definitions.
+      # TODO: Add firefox.
+      "@io_bazel_rules_webtesting//browsers:chromium-local",
+  ])
+
+  js_test(**kwargs)

--- a/tools/gen_test_html.template
+++ b/tools/gen_test_html.template
@@ -1,5 +1,4 @@
-<script src="/filez/polyfill/src/native-shim.js"></script>
-<script src="/filez/polyfill/custom-elements.min.js"></script>
+<!doctype html>
 <!--
 Copyright (c) 2018 Google Inc.
 
@@ -15,3 +14,16 @@ WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 License for the specific language governing permissions and limitations under
 the License.
 -->
+
+<!--
+This is a template of the default test file used for running JS tests
+declared with js_test or closure_js_test rules.
+-->
+<script src="/external/polyfill/custom-elements.min.js"></script>
+<script>
+  // goog.require does not need to fetch sources from the local
+  // server because everything is compiled and loaded explicitly below.
+  var CLOSURE_NO_DEPS = true;
+  var CLOSURE_UNCOMPILED_DEFINES = {};
+</script>
+<script src="{{TEST_FILE_JS}}"></script>

--- a/tools/server.go
+++ b/tools/server.go
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// The server command starts a simple static file server using current work dir
+// as the root directory.
 package main
 
 import (
@@ -21,7 +23,7 @@ import (
 	"os"
 )
 
-var addr = flag.String("addr", "localhost:8080", "Server address to bind to")
+var addr = flag.String("addr", "localhost:8080", "Server address to bind to.")
 
 func main() {
 	flag.Parse()

--- a/tools/webtest.go
+++ b/tools/webtest.go
@@ -1,0 +1,158 @@
+// Copyright 2018 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// The webtest command runs a Google Closure based JS tests.
+// It exits with non-zero code if any of the tests fail.
+package main
+
+import (
+	"encoding/json"
+	"flag"
+	"fmt"
+	"log"
+	"net"
+	"net/http"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/bazelbuild/rules_webtesting/go/webtest"
+	"github.com/tebeka/selenium"
+)
+
+var (
+	testURL = flag.String("test_url", "/demo/hello_test.html", "Initial URL to start the tests.")
+	host    = flag.String("host", "localhost", "Host to bind static server to.")
+	debug   = flag.Bool("debug", false, "Enable verbose logging.")
+)
+
+func main() {
+	log.SetPrefix("[tools/webtest] ")
+	flag.Parse()
+	if *debug {
+		log.Printf("arguments: \n\t%s", strings.Join(os.Args, "\n\t"))
+		info, err := webtest.GetBrowserInfo()
+		if err != nil {
+			log.Fatalf("get browser info: %v", err)
+		}
+		log.Printf("webtest browser: %s", info.BrowserLabel)
+		log.Printf("webtest environment: %s", info.Environment)
+	}
+	if *testURL == "" {
+		log.Fatal("--test_url argument is required")
+	}
+	if !strings.HasPrefix(*testURL, "/") {
+		*testURL = "/" + *testURL
+	}
+
+	cwdir, err := os.Getwd()
+	if err != nil {
+		log.Fatalf("getwd: %v", err)
+	}
+	addr, err := serve(cwdir, *host)
+	if err != nil {
+		log.Fatalf("serve: %v", err)
+	}
+	debugf("serving on %s; root dir: %s", addr, cwdir)
+
+	// TODO: Consider making capabilities configurable.
+	drv, err := webtest.NewWebDriverSession(selenium.Capabilities{})
+	if err != nil {
+		log.Fatalf("webdriver new session: %v", err)
+	}
+	runURL := fmt.Sprintf("http://%s%s", addr, *testURL)
+	debugf("running tests on URL: %s", runURL)
+	runErr := run(drv, runURL)
+	if err := drv.Quit(); err != nil {
+		log.Printf("webdriver quit: %v", err)
+	}
+	if runErr != nil {
+		log.Fatal(runErr)
+	}
+}
+
+func serve(root, host string) (addr string, err error) {
+	l, err := net.Listen("tcp", host+":")
+	if err != nil {
+		return "", err
+	}
+
+	go func() {
+		fs := http.FileServer(http.Dir(root))
+		h := func(w http.ResponseWriter, r *http.Request) {
+			debugf("%s %s", r.Method, r.URL)
+			fs.ServeHTTP(w, r)
+		}
+		errServe := http.Serve(l, http.HandlerFunc(h))
+		log.Fatalf("serve(%q): %v", root, errServe)
+	}()
+
+	return l.Addr().String(), nil
+}
+
+// TODO: Make run timeout and configurable based on test size (small, large, etc.)
+func run(drv selenium.WebDriver, testURL string) error {
+	if err := drv.Get(testURL); err != nil {
+		return fmt.Errorf("webdriver GET %s: %v", testURL, err)
+	}
+	if err := waitTests(drv); err != nil {
+		return fmt.Errorf("waitTests: %v", err)
+	}
+	v, err := drv.ExecuteScript(`return window.top.G_testRunner.getTestResultsAsJson();`, nil)
+	if err != nil {
+		return fmt.Errorf("G_testRunner.getTestResultsAsJson: %v", err)
+	}
+	var results map[string][]*struct{ Message, Stacktrace string }
+	if err := json.Unmarshal([]byte(v.(string)), &results); err != nil {
+		return fmt.Errorf("G_testRunner.getTestResultsAsJson unmarshal: %v", err)
+	}
+	var (
+		nfail int
+		fails strings.Builder
+	)
+	for name, res := range results {
+		switch {
+		default:
+			debugf("%s: OK", name)
+		case len(res) > 0:
+			nfail++
+			fmt.Fprintf(&fails, "%s: FAIL\n", name)
+			for i, item := range res {
+				fmt.Fprintf(&fails, "%d. %s\n%s\n", i+1, item.Message, item.Stacktrace)
+			}
+		}
+	}
+	if nfail > 0 {
+		return fmt.Errorf("%d out of %d test(s) failed:\n%s", nfail, len(results), &fails)
+	}
+	return nil
+}
+
+func waitTests(drv selenium.WebDriver) error {
+	f := func(drv selenium.WebDriver) (bool, error) {
+		v, err := drv.ExecuteScript(`return window.top.G_testRunner.isFinished();`, nil)
+		if err != nil {
+			return false, fmt.Errorf("G_testRunner.isFinished: %v", err)
+		}
+		return v.(bool), nil
+	}
+	// TODO: make interval configurable based on test size (small, large, etc.)
+	return drv.WaitWithTimeoutAndInterval(f, time.Minute, 100*time.Millisecond)
+}
+
+func debugf(format string, args ...interface{}) {
+	if *debug {
+		log.Printf(format, args...)
+	}
+}


### PR DESCRIPTION
This is a checkpoint at which we can start writing codelab custom elements.
Notable updates and changes:

- Replaced rules_closure's phantomjs-based test runner with real browsers
  reusing the work from rules_webtesting: https://github.com/bazelbuild/rules_webtesting.
  The runner is now a simple Go program, connecting to a selenium hub
  instantiated by web_test_suite rule and checking results via G_testRunner.
  See //demo:hello_test target and tools/webtest.go.

- The closure_js_{library,binary} now have suitable default attribute
  values. See //demo:hello_lib and //demo:hello_bin targets.

- A minimal readme, doc comments and updated license.

/cc @skarEE @markmcd @arkassay