### PR TITLE
initial check in of a test

### DIFF
--- a/google-codelab-step/BUILD
+++ b/google-codelab-step/BUILD
@@ -50,3 +50,10 @@ closure_js_template_library(
     name = "google_codelab_step_soy",
     srcs = ["google_codelab_step.soy"]
 )
+
+closure_js_test(
+    name = "google_codelab_step_test",
+    srcs = ["google_codelab_step_test.js"],
+    entry_points = ["googlecodelabs.CodelabStepTest"],
+    deps = [":google_codelab_step"],
+)

--- a/google-codelab-step/google_codelab_step_test.js
+++ b/google-codelab-step/google_codelab_step_test.js
@@ -1,0 +1,29 @@
+/**
+ * Copyright 2018 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+goog.module('googlecodelabs.CodelabStepTest');
+goog.setTestOnly();
+
+const CodelabSurvey = goog.require('googlecodelabs.CodelabStep');
+const testSuite = goog.require('goog.testing.testSuite');
+goog.require('goog.testing.asserts');
+goog.require('goog.testing.jsunit');
+
+testSuite({
+  testMoo() {
+      assertTrue(false);
+  }
+});


### PR DESCRIPTION
Failure message:

google-codelab-step/google_codelab_step.js:76: ERROR - @export only applies to symbols/properties defined in the global scope.
  static get observedAttributes() {
             ^
  ProTip: "JSC_NON_GLOBAL_ERROR" can be added to the `suppress` attribute of:
  //google-codelab-step:google_codelab_step