### PR TITLE
tools: allow ES6 getter @export + closure updates

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -11,10 +11,10 @@ http_archive(
     ],
 )
 
-rules_closure_ver = "f4d0633f14570313b94822223039ebda0f398102"
+rules_closure_ver = "dbb96841cc0a5fb2664c37822803b06dab20c7d1"
 http_archive(
     name = "io_bazel_rules_closure",
-    sha256 = "8e615c1c282ba680e667549e242cfcc0643846ee7c0c8c816bee077b3edda567",
+    sha256 = "6c493fc2ebc7b05be63171e8d5d57ebe5a73e8b0c57a14f477147af3f4dba1c2",
     strip_prefix = "rules_closure-{v}".format(v=rules_closure_ver),
     url = "https://github.com/bazelbuild/rules_closure/archive/{v}.zip".format(v=rules_closure_ver),
 )

--- a/tools/defs.bzl
+++ b/tools/defs.bzl
@@ -26,11 +26,7 @@ def closure_js_library(**kwargs):
   """
   kwargs.setdefault("convention", "GOOGLE")
   suppress = kwargs.pop("suppress", [])
-  suppress.append("JSC_NTI_INVALID_INDEX_TYPE")
   suppress.append("JSC_NTI_UNKNOWN_EXPR_TYPE")
-  suppress.append("checkTypes")
-  suppress.append("newCheckTypes")
-  suppress.append("newCheckTypesCompatibility")
   kwargs.update(dict(suppress=suppress))
   _closure_js_library_alias(**kwargs)
 
@@ -148,9 +144,9 @@ def js_test(name,
       css = css,
       debug = True,
       defs = [
-          "--new_type_inf",
           "--rewrite_polyfills=false",
           "--jscomp_off=analyzerChecks",
+          "--export_local_property_definitions",
       ],
       language = "ECMASCRIPT_2015",
       dependency_mode = "LOOSE",


### PR DESCRIPTION
@skarEE this should fix a closure compiler error in #13:

     @export only applies to symbols/properties defined
     in the global scope.

It is fixed by enabling export_local_property_definitions flag.
Unfortunately, it also results in NullPointerException
due to the new_type_inf flag. So, the latter had to go for tests.

The change also removes some of the suppress arguments
to the closure_js_library rules because they are unused anyway:
the compilation happens in closure_js_binary targets.

Lastly, upgraded rules_closure to the latest HEAD,
which supposedly makes a better use of the Closure Compiler.