### PR TITLE
google-codelab: skip non-parseable duration

### DIFF
--- a/google-codelab/google_codelab.js
+++ b/google-codelab/google_codelab.js
@@ -481,7 +481,10 @@ class Codelab extends HTMLElement {
     let time = 0;
     for (let i = this.currentSelectedStep_; i < this.steps_.length; i++) {
       const step = /** @type {!Element} */ (this.steps_[i]);
-      time += parseInt(step.getAttribute(DURATION_ATTR), 10);
+      let n = parseInt(step.getAttribute(DURATION_ATTR), 10);
+      if (n) {
+        time += n;
+      }
     }
 
     const newTimeEl =  soy.renderAsElement(Templates.timeRemaining, {time});


### PR DESCRIPTION
Some steps may not specify duration. This resulted in the total
codelab time to be NaN.

So, only count duration values which are greater than 0.

Fixes #40