### PR TITLE
Create a bundle target for distribution

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1,5 +1,71 @@
 package(default_visibility = ["//visibility:public"])
 
+load("//tools:defs.bzl", "concat")
+
 licenses(["notice"])
 
-exports_files(["LICENSE"])
+exports_files(["LICENSE", "README.md"])
+
+filegroup(
+    name = "all_files",
+    srcs = [
+        ":codelab_elements_js",
+        ":codelab_elements_css",
+        ":codelab_index_js",
+        ":codelab_index_css",
+    ],
+)
+
+genrule(
+    name = "bundle",
+    outs = ["bundle.zip"],
+    srcs = [
+        "LICENSE",
+        "README.md",
+        ":all_files",
+        "@prettify//:prettify",
+        "@polyfill//:custom_elements",
+        "@polyfill//:native_shim",
+    ],
+    cmd = "zip -j $@ $(SRCS)",
+)
+
+genrule(
+    name = "codelab_elements_js",
+    outs = ["codelab-elements.js"],
+    srcs = [
+        "//google-codelab:google_codelab_bin",
+        "//google-codelab-step:google_codelab_step_bin",
+        "//google-codelab-survey:google_codelab_survey_bin",
+    ],
+    cmd = concat("js"),
+)
+
+genrule(
+    name = "codelab_elements_css",
+    outs = ["codelab-elements.css"],
+    srcs = [
+        "//google-codelab:google_codelab_scss_bin",
+        "//google-codelab-step:google_codelab_step_scss_bin",
+        "//google-codelab-survey:google_codelab_survey_scss_bin",
+    ],
+    cmd = concat("css"),
+)
+
+genrule(
+    name = "codelab_index_js",
+    outs = ["codelab-index.js"],
+    srcs = [
+        "//google-codelab-index:google_codelab_index_bin",
+    ],
+    cmd = concat("js"),
+)
+
+genrule(
+    name = "codelab_index_css",
+    outs = ["codelab-index.css"],
+    srcs = [
+        "//google-codelab-index:google_codelab_index_scss_bin",
+    ],
+    cmd = concat("css"),
+)

--- a/README.md
+++ b/README.md
@@ -4,6 +4,41 @@ The next generation of the codelab elements without any framework or library
 dependencies, only the [Custom Elements](https://html.spec.whatwg.org/multipage/custom-elements.html)
 standard spec.
 
+If this is a release bundle, produced with a `bazel build :bundle` command,
+you should see `codelab-elements.js`, `codelab-elements.css` and other files,
+ready to be added to an HTML page like the following. Only relevant parts are shown:
+
+```html
+<!doctype html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, minimum-scale=1.0, initial-scale=1.0, user-scalable=yes">
+  <title>A codelab demo</title>
+  <link rel="stylesheet" href="//fonts.googleapis.com/css?family=Source+Code+Pro:400|Roboto:400,300,400italic,500,700|Roboto+Mono">
+  <link rel="stylesheet" href="//fonts.googleapis.com/icon?family=Material+Icons">
+  <link rel="stylesheet" href="codelab-elements.css">
+</head>
+<body>
+  <google-codelab id="codelab-demo" title="A codelab demo">
+    <google-codelab-step label="Overview" duration="1">
+      Contents of the first step.
+    </google-codelab-step>
+    <google-codelab-step label="Second" duration="10">
+      Contents of the second step.
+    </google-codelab-step>
+  </google-codelab>
+  <script src="native-shim.js"></script>
+  <script src="custom-elements.min.js"></script>
+  <script src="prettify.js"></script>
+  <script src="codelab-elements.js"></script>
+</body>
+</html>
+```
+
+You can download the latest version
+from https://github.com/googlecodelabs/codelab-elements.
+
 ## Dev environment
 
 All you need is [bazel](https://docs.bazel.build/versions/master/install.html).

--- a/tools/defs.bzl
+++ b/tools/defs.bzl
@@ -20,6 +20,10 @@ load("@io_bazel_rules_closure//closure:defs.bzl",
      _closure_js_library_alias="closure_js_library")
 load("@io_bazel_rules_webtesting//web:web.bzl", "web_test_suite")
 
+def concat(ext):
+    """Returns a genrule command to concat files with the extension ext."""
+    return "ls $(SRCS) | grep -E '\.{ext}$$' | xargs cat > $@".format(ext=ext)
+
 def closure_js_library(**kwargs):
   """Invokes actual closure_js_library with defaults suitable
   for non-test JS source files.


### PR DESCRIPTION
This creates :bundle build target which produces a zip file
with the following contents

```
Archive:  bazel-genfiles/bundle.zip
  Length      Date    Time    Name
---------  ---------- -----   ----
    11358  2018-04-09 22:46   LICENSE
     3297  2018-06-13 20:21   README.md
    50953  2018-06-13 20:02   codelab-elements.js
    25902  2018-06-13 20:02   codelab-elements.css
    21456  2018-06-13 20:29   codelab-index.js
    21765  2018-06-13 20:29   codelab-index.css
    63320  2013-03-04 12:16   prettify.js
    14696  2018-01-11 15:07   custom-elements.min.js
    96093  2018-01-11 15:07   custom-elements.min.js.map
     7095  2018-01-11 15:07   native-shim.js
---------                     -------
   315935                     10 files
```

Updates https://github.com/googlecodelabs/codelab-elements/issues/6 and https://github.com/googlecodelabs/tools/issues/42.

Also, having this bundle will make it faster for https://g.co/codelabs to migrate to codelab-elements.