### PR TITLE
Codelabs analytics

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -34,6 +34,7 @@ genrule(
     name = "codelab_elements_js",
     outs = ["codelab-elements.js"],
     srcs = [
+        "//google-codelab-analytics:google_codelab_analytics_bin",
         "//google-codelab:google_codelab_bin",
         "//google-codelab-step:google_codelab_step_bin",
         "//google-codelab-survey:google_codelab_survey_bin",

--- a/README.md
+++ b/README.md
@@ -20,7 +20,8 @@ ready to be added to an HTML page like the following. Only relevant parts are sh
   <link rel="stylesheet" href="codelab-elements.css">
 </head>
 <body>
-  <google-codelab id="codelab-demo" title="A codelab demo">
+  <google-codelab-analytics gaid="UA-123"></google-codelab-analytics>
+  <google-codelab codelab-gaid="UA-345" id="codelab-demo" title="A codelab demo">
     <google-codelab-step label="Overview" duration="1">
       Contents of the first step.
     </google-codelab-step>

--- a/google-codelab-analytics/BUILD.bazel
+++ b/google-codelab-analytics/BUILD.bazel
@@ -1,0 +1,31 @@
+package(default_visibility = ["//visibility:public"])
+
+licenses(["notice"])
+
+exports_files(["LICENSE"])
+
+load("//tools:defs.bzl", "closure_js_library", "closure_js_binary")
+
+
+filegroup(
+    name = "google_codelab_analytics_files",
+    srcs = [
+      ":google_codelab_analytics_bin",
+    ],
+)
+
+# Codelab Analytics.
+closure_js_library(
+    name = "google_codelab_analytics",
+    srcs = ["google_codelab_analytics.js"],
+    deps = [
+        "@io_bazel_rules_closure//closure/library",
+    ],
+)
+
+# Compiled version of GoogleCodelabAnalytics element, suitable for distribution.
+closure_js_binary(
+    name = "google_codelab_analytics_bin",
+    entry_points = ["googlecodelabs.CodelabAnalytics"],
+    deps = [":google_codelab_analytics"],
+)

--- a/google-codelab-analytics/BUILD.bazel
+++ b/google-codelab-analytics/BUILD.bazel
@@ -4,7 +4,8 @@ licenses(["notice"])
 
 exports_files(["LICENSE"])
 
-load("//tools:defs.bzl", "closure_js_library", "closure_js_binary")
+load("//tools:defs.bzl",
+     "closure_js_library", "closure_js_binary", "closure_js_test")
 
 
 filegroup(
@@ -20,6 +21,17 @@ closure_js_library(
     srcs = ["google_codelab_analytics.js"],
     deps = [
         "@io_bazel_rules_closure//closure/library",
+    ],
+)
+
+# Codelab Analytics Tests
+closure_js_test(
+    name = "google_codelab_analytics_test",
+    srcs = ["google_codelab_analytics_test.js"],
+    entry_points = ["googlecodelabs.CodelabAnalyticsTest"],
+    deps = [
+      "@io_bazel_rules_closure//closure/library",
+      ":google_codelab_analytics"
     ],
 )
 

--- a/google-codelab-analytics/google_codelab_analytics.js
+++ b/google-codelab-analytics/google_codelab_analytics.js
@@ -1,0 +1,80 @@
+/**
+ * @license
+ * Copyright 2018 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+goog.module('googlecodelabs.CodelabAnalytics');
+
+const EventHandler = goog.require('goog.events.EventHandler');
+
+/**
+ * The general codelab action event fired for trackable interactions.
+ */
+const GOOGLE_CODELAB_ACTION_EVENT = 'google-codelab-action';
+
+/**
+ * Event detail passed when firing GOOGLE_CODELAB_ACTION_EVENT.
+ *
+ * @typedef {{
+ *  category: string,
+ *  action: string,
+ *  label: (?string|undefined),
+ *  value: (?number|undefined)
+ * }}
+ */
+let AnalyticsTrackingEvent;
+
+
+/**
+ * @extends {HTMLElement}
+ * @suppress {reportUnknownTypes}
+ */
+class CodelabAnalytics extends HTMLElement {
+  constructor() {
+    super();
+
+    this.hasSetup_ = false;
+
+    /** @private {!EventHandler} */
+    this.eventHandler_ = new EventHandler();
+  }
+
+  connectedCallback() {
+    if (this.hasSetup_) {
+      return;
+    }
+
+    this.hasSetup_ = true;
+    this.addEventListeners_();
+  }
+
+  addEventListeners_() {
+    this.eventHandler_.listen(document.body, GOOGLE_CODELAB_ACTION_EVENT,
+      (e) => {
+        const detail = /** @type {AnalyticsTrackingEvent} */ (
+          e.getBrowserEvent().detail);
+        // Add tracking...
+        console.log(detail);
+      });
+  }
+
+  disconnectedCallback() {
+    this.eventHandler_.removeAll();
+  }
+}
+
+window.customElements.define('google-codelab-analytics', CodelabAnalytics);
+
+exports = CodelabAnalytics;

--- a/google-codelab-analytics/google_codelab_analytics.js
+++ b/google-codelab-analytics/google_codelab_analytics.js
@@ -22,7 +22,32 @@ const EventHandler = goog.require('goog.events.EventHandler');
 /**
  * The general codelab action event fired for trackable interactions.
  */
-const GOOGLE_CODELAB_ACTION_EVENT = 'google-codelab-action';
+const ACTION_EVENT = 'google-codelab-action';
+
+/**
+ * The general codelab pageview event fired for trackable pageviews.
+ */
+const PAGEVIEW_EVENT = 'google-codelab-pageview';
+
+/**
+ * The Google Analytics ID. Analytics CE will not complete initialization
+ * without a valid Analytics ID value set for this.
+ * @const {string}
+ */
+const GAID_ATTR = 'gaid';
+
+/**
+ * The GAID defined by the current codelab.
+ * @const {string}
+ */
+const CODELAB_GAID_ATTR = 'codelab-gaid';
+
+/** @const {string} */
+const CODELAB_ENV_ATTR = 'environment';
+
+/** @const {string} */
+const CODELAB_CATEGORY_ATTR = 'category';
+
 
 /**
  * Event detail passed when firing GOOGLE_CODELAB_ACTION_EVENT.
@@ -45,33 +70,197 @@ class CodelabAnalytics extends HTMLElement {
   constructor() {
     super();
 
+    /** @private {boolean} */
     this.hasSetup_ = false;
+
+    /** @private {?string} */
+    this.gaid_ = this.getAttribute(GAID_ATTR) || '';
 
     /** @private {!EventHandler} */
     this.eventHandler_ = new EventHandler();
+
+    /** @private {!EventHandler} */
+    this.pageviewEventHandler_ = new EventHandler();
+
+    /** @private {?string} */
+    this.codelabCategory_ = this.getAttribute(CODELAB_CATEGORY_ATTR) || '';
+
+    /** @private {?string} */
+    this.codelabEnv_ = this.getAttribute(CODELAB_ENV_ATTR) || '';
   }
 
+  /**
+   * @export
+   * @override
+   */
   connectedCallback() {
-    if (this.hasSetup_) {
+    if (this.hasSetup_ || !this.gaid_) {
       return;
     }
 
     this.hasSetup_ = true;
+    this.initGAScript_();
+    this.trackPageView_();
     this.addEventListeners_();
   }
 
   addEventListeners_() {
-    this.eventHandler_.listen(document.body, GOOGLE_CODELAB_ACTION_EVENT,
+    this.eventHandler_.listen(document.body, ACTION_EVENT,
       (e) => {
         const detail = /** @type {AnalyticsTrackingEvent} */ (
           e.getBrowserEvent().detail);
         // Add tracking...
-        console.log(detail);
+        this.trackEvent_(
+          detail.category, detail.action, detail.label, detail.value);
+      });
+
+    this.pageviewEventHandler_.listen(document.body, PAGEVIEW_EVENT,
+      (e) => {
+        const detail = e.getBrowserEvent().detail;
+        this.trackPageView_(detail.page, detail.title);
       });
   }
 
+  /**
+   * @return {!Array<string>}
+   * @export
+   */
+  static get observedAttributes() {
+    return [CODELAB_GAID_ATTR, CODELAB_ENV_ATTR, CODELAB_CATEGORY_ATTR];
+  }
+
+  /**
+   * @param {string} attr
+   * @param {?string} oldValue
+   * @param {?string} newValue
+   * @param {?string} namespace
+   * @export
+   * @override
+   */
+  attributeChangedCallback(attr, oldValue, newValue, namespace) {
+    switch (attr) {
+      case CODELAB_GAID_ATTR:
+        if (newValue) {
+          this.createCodelabGATracker_(newValue);
+        }
+        break;
+      case CODELAB_ENV_ATTR:
+        this.codelabEnv_ = newValue;
+        break;
+      case CODELAB_CATEGORY_ATTR:
+        this.codelabCategory_ = newValue;
+        break;
+    }
+  }
+
+  /**
+   * Fires an analytics tracking event to all configured trackers.
+   *
+   * @param {string} category The event category.
+   * @param {string=} opt_action The event action.
+   * @param {?string=} opt_label The event label.
+   * @param {?number=} opt_value The event value.
+   * @export
+   */
+  trackEvent_(category, opt_action, opt_label, opt_value) {
+    const params = {
+      // Always event for trackEvent_ method
+      'hitType': 'event',
+      'dimension1': this.codelabEnv_,
+      'dimension2': this.codelabCategory_,
+      'eventCategory': category,
+      'eventAction': opt_action || '',
+      'eventLabel': opt_label || '',
+      'eventValue': opt_value || '',
+    };
+    console.log('event params: ', params);
+    this.gaSend_(params);
+  }
+
+  /**
+   * @param {?string=} opt_page The page to track.
+   * @param {?string=} opt_title The codelabs title.
+   */
+  trackPageView_(opt_page, opt_title) {
+    const params = {
+      'hitType': 'pageview',
+      'dimension1': this.codelabEnv_,
+      'dimension2': this.codelabCategory_,
+      'page': opt_page || '',
+      'title': opt_title || ''
+    };
+    console.log('pageview params: ', params);
+    this.gaSend_(params);
+  }
+
+  gaSend_(params) {
+    window['ga'](function() {
+      const trackers = window['ga'].getAll();
+      trackers.forEach((tracker) => {
+        tracker.send(params);
+      });
+    });
+  }
+
+  /**
+   * @export
+   * @override
+   */
   disconnectedCallback() {
     this.eventHandler_.removeAll();
+  }
+
+  /**
+   * Creates a GA tracker.
+   * @param {string} codelabGAId A GAID for an account.
+   */
+  createCodelabGATracker_(codelabGAId) {
+    // Make sure sure that tracker gets created only once per session.
+    // Also makes sure the script wasn't already included in the html.
+    if (!goog.isDef(window['ga'])) {
+      this.initGAScript_();
+    }
+
+    if (!window['ga']['getByName']('codelabAccount')) {
+      window['ga']('create', codelabGAId, 'auto', 'codelabAccount');
+    }
+  }
+
+  getGAView_() {
+    let parts = location.search.substring(1).split('&');
+    for (let i = 0; i < parts.length; i++) {
+      let param = parts[i].split('=');
+      if (param[0] === 'viewga') {
+        return param[1];
+      }
+    }
+    return '';
+  }
+
+  initGAScript_() {
+    // Make sure sure that tracker gets created only once per session.
+    // Also makes sure the script wasn't already included in the html.
+    if (goog.isDef(window['ga'])) {
+      return;
+    }
+
+    // This is a pretty-printed version of the function(i,s,o,g,r,a,m) script
+    // provided by Google Analytics.
+    window['GoogleAnalyticsObject'] = 'ga';
+    window['ga'] = window['ga'] || function() {
+      (window['ga']['q'] = window['ga']['q'] || []).push(arguments);
+    };
+    window['ga']['l'] = (new Date()).valueOf();
+
+    if (this.gaid_) {
+      window['ga']('create', this.gaid_, 'auto');
+    }
+
+    const gaView = this.getGAView_();
+    if (gaView) {
+      window['ga']('create', gaView, 'auto', {name: 'view'});
+      window['ga']('view.send', 'pageview');
+    }
   }
 }
 

--- a/google-codelab-analytics/google_codelab_analytics.js
+++ b/google-codelab-analytics/google_codelab_analytics.js
@@ -187,12 +187,11 @@ class CodelabAnalytics extends HTMLElement {
 
   /**
    * Fires an analytics tracking event to all configured trackers.
-   *
    * @param {string} category The event category.
    * @param {string=} opt_action The event action.
    * @param {?string=} opt_label The event label.
    * @param {?number=} opt_value The event value.
-   * @export
+   * @private
    */
   trackEvent_(category, opt_action, opt_label, opt_value) {
     const params = {
@@ -211,6 +210,7 @@ class CodelabAnalytics extends HTMLElement {
   /**
    * @param {?string=} opt_page The page to track.
    * @param {?string=} opt_title The codelabs title.
+   * @private
    */
   trackPageview_(opt_page, opt_title) {
     const params = {
@@ -223,6 +223,7 @@ class CodelabAnalytics extends HTMLElement {
     this.gaSend_(params);
   }
 
+  /** @private */
   gaSend_(params) {
     window['ga'](function() {
       const trackers = window['ga'].getAll();
@@ -240,6 +241,7 @@ class CodelabAnalytics extends HTMLElement {
     this.eventHandler_.removeAll();
   }
 
+  /** @private */
   getGAView_() {
     let parts = location.search.substring(1).split('&');
     for (let i = 0; i < parts.length; i++) {
@@ -274,6 +276,7 @@ class CodelabAnalytics extends HTMLElement {
     });
   }
 
+  /** @private */
   async initGAScript_() {
     // This is a pretty-printed version of the function(i,s,o,g,r,a,m) script
     // provided by Google Analytics.
@@ -290,6 +293,7 @@ class CodelabAnalytics extends HTMLElement {
     }
   }
 
+  /** @private */
   createTrackers_() {
     // The default tracker is given name 't0' per analytics.js dev docs.
     if (this.gaid_ && !this.isTrackerCreated_(this.gaid_)) {
@@ -307,6 +311,7 @@ class CodelabAnalytics extends HTMLElement {
 
   /**
    * Creates a GA tracker specific to the codelab.
+   * @private
    */
   createCodelabGATracker_() {
     const codelabGAId = this.getAttribute(CODELAB_GAID_ATTR);

--- a/google-codelab-analytics/google_codelab_analytics.js
+++ b/google-codelab-analytics/google_codelab_analytics.js
@@ -115,12 +115,16 @@ class CodelabAnalytics extends HTMLElement {
 
     this.initGAScript_().then((response) => {
       if (response) {
-        this.createTrackers_();
-        this.trackPageview_();
-        this.addEventListeners_();
-        this.hasSetup_ = true;
+        this.init_();
       }
     });
+  }
+
+  init_() {
+    this.createTrackers_();
+    this.trackPageview_();
+    this.addEventListeners_();
+    this.hasSetup_ = true;
   }
 
   addEventListeners_() {
@@ -281,7 +285,9 @@ class CodelabAnalytics extends HTMLElement {
         return null;
       }
     }
-    return Promise.resolve();
+
+    this.init_();
+    return null;
   }
 
   createTrackers_() {

--- a/google-codelab-analytics/google_codelab_analytics.js
+++ b/google-codelab-analytics/google_codelab_analytics.js
@@ -116,7 +116,7 @@ class CodelabAnalytics extends HTMLElement {
     this.hasSetup_ = true;
     this.initGAScript_();
     // Now track a page view and add the rest of the event listeners...
-    this.trackPageView_();
+    this.trackPageview_();
     this.addEventListeners_();
   }
 
@@ -132,8 +132,9 @@ class CodelabAnalytics extends HTMLElement {
 
     this.pageviewEventHandler_.listen(document.body, PAGEVIEW_EVENT,
       (e) => {
-        const detail = e.getBrowserEvent().detail;
-        this.trackPageView_(detail.page, detail.title);
+        const detail = /** @type {AnalyticsPageview} */ (
+          e.getBrowserEvent().detail);
+        this.trackPageview_(detail.page, detail.title);
       });
   }
 
@@ -199,7 +200,7 @@ class CodelabAnalytics extends HTMLElement {
    * @param {?string=} opt_page The page to track.
    * @param {?string=} opt_title The codelabs title.
    */
-  trackPageView_(opt_page, opt_title) {
+  trackPageview_(opt_page, opt_title) {
     const params = {
       'hitType': 'pageview',
       'dimension1': this.codelabEnv_,
@@ -259,7 +260,7 @@ class CodelabAnalytics extends HTMLElement {
    * @return {!Promise}
    * @export
    */
-  static injectGAscript() {
+  static injectGAScript() {
     const resource = document.createElement('script');
     resource.src = '//www.google-analytics.com/analytics.js';
     resource.async = false;
@@ -293,7 +294,7 @@ class CodelabAnalytics extends HTMLElement {
       window['ga']['l'] = (new Date()).valueOf();
 
       try {
-        await CodelabAnalytics.injectGAscript();
+        await CodelabAnalytics.injectGAScript();
       } catch(e) {
         console.log(`Failed to load GA Script: ${e.message}`);
       }
@@ -316,9 +317,17 @@ class CodelabAnalytics extends HTMLElement {
   /**
    * @param {string} trackerId The tracker ID to check for.
    * @return {boolean}
+   * @private
    */
   isTrackerCreated_(trackerId) {
-    return this.trackerIds_.indexOf(trackerId) > -1;
+    const allTrackers = window['ga'].getAll();
+    let isCreated = false;
+    allTrackers.forEach((tracker) => {
+      if (tracker.get('trackingId') == trackerId) {
+        isCreated = true;
+      }
+    });
+    return isCreated;
   }
 }
 

--- a/google-codelab-analytics/google_codelab_analytics.js
+++ b/google-codelab-analytics/google_codelab_analytics.js
@@ -317,17 +317,9 @@ class CodelabAnalytics extends HTMLElement {
   /**
    * @param {string} trackerId The tracker ID to check for.
    * @return {boolean}
-   * @private
    */
   isTrackerCreated_(trackerId) {
-    const allTrackers = window['ga'].getAll();
-    let isCreated = false;
-    allTrackers.forEach((tracker) => {
-      if (tracker.get('trackingId') == trackerId) {
-        isCreated = true;
-      }
-    });
-    return isCreated;
+    return this.trackerIds_.indexOf(trackerId) > -1;
   }
 }
 

--- a/google-codelab-analytics/google_codelab_analytics.js
+++ b/google-codelab-analytics/google_codelab_analytics.js
@@ -163,7 +163,7 @@ class CodelabAnalytics extends HTMLElement {
         this.gaid_ = newValue;
         break;
       case CODELAB_GAID_ATTR:
-        if (newValue & this.hasSetup_) {
+        if (newValue && this.hasSetup_) {
           this.createCodelabGATracker_();
         }
         break;

--- a/google-codelab-analytics/google_codelab_analytics.js
+++ b/google-codelab-analytics/google_codelab_analytics.js
@@ -241,7 +241,10 @@ class CodelabAnalytics extends HTMLElement {
     this.eventHandler_.removeAll();
   }
 
-  /** @private */
+  /**
+   * @return {string}
+   * @private
+   */
   getGAView_() {
     let parts = location.search.substring(1).split('&');
     for (let i = 0; i < parts.length; i++) {
@@ -276,7 +279,10 @@ class CodelabAnalytics extends HTMLElement {
     });
   }
 
-  /** @private */
+  /**
+   * @return {!Promise}
+   * @private
+   */
   async initGAScript_() {
     // This is a pretty-printed version of the function(i,s,o,g,r,a,m) script
     // provided by Google Analytics.

--- a/google-codelab-analytics/google_codelab_analytics_test.js
+++ b/google-codelab-analytics/google_codelab_analytics_test.js
@@ -46,30 +46,46 @@ testSuite({
   },
 
   testGAIDAttr_InitsTracker() {
-    const mockGa = mockControl.createFunctionMock('ga');
     const analytics = new CodelabAnalytics();
-    // const mockInitGA = mockControl.createMethodMock(analytics, 'initGAScript_');
+
+    // Need to mock as we don't have window.ga.getAll()
+    const mockGetAll = mockControl.createFunctionMock('getAll');
+    const mockCreate = mockControl.createFunctionMock('create');
+    mockGetAll().$returns([]).$anyTimes();
+    mockCreate().$once();
+
     analytics.setAttribute('gaid', 'UA-123');
-    // mockInitGA().$returns(Promise.resolve()).$once();
-    mockGa('getAll').$returns([]).$once();
-    mockGa('create', 'UA-123', 'auto').$once();
-    window['ga'] = mockGa;
+
+    window['ga'] = (...args) => {
+      window['ga'][args[0]]();
+    };
+    window['ga']['getAll'] = mockGetAll;
+    window['ga']['create'] = mockCreate;
+
     mockControl.$replayAll();
     document.body.appendChild(analytics);
     mockControl.$verifyAll();
   },
 
   testViewParam_InitsViewTracker() {
-    const mockGa = mockControl.createFunctionMock('ga');
     const analytics = new CodelabAnalytics();
     analytics.setAttribute('gaid', 'UA-123');
     const locationSearchSaved = location.search;
     location.search = '?viewga=testView&param2=hi';
-    mockGa('getAll').$returns([]).$once();
-    mockGa('create', 'UA-123', 'auto').$once();
-    mockGa('getAll').$returns([]).$once();
-    mockGa('create', 'testView', 'auto', 'view').$once();
-    window['ga'] = mockGa;
+
+    // Need to mock as we don't have window.ga.getAll()
+    const mockGetAll = mockControl.createFunctionMock('getAll');
+    const mockCreate = mockControl.createFunctionMock('create');
+    mockGetAll().$returns([]).$anyTimes();
+    // Creates 2 trackers (because of view param).
+    mockCreate().$times(2);
+
+    window['ga'] = (...args) => {
+      window['ga'][args[0]]();
+    };
+    window['ga']['getAll'] = mockGetAll;
+    window['ga']['create'] = mockCreate;
+
     mockControl.$replayAll();
 
     document.body.appendChild(analytics);
@@ -79,14 +95,21 @@ testSuite({
   },
 
   testCodelabGAIDAttr_InitsCodelabTracker() {
-    const mockGa = mockControl.createFunctionMock('ga');
     const analytics = new CodelabAnalytics();
     analytics.setAttribute('gaid', 'UA-123');
-    mockGa('getAll').$returns([]).$once();
-    mockGa('create', 'UA-123', 'auto').$once();
-    mockGa('getAll').$returns([]).$once();
-    mockGa('create', 'UA-456', 'auto', 'codelabAccount').$once();
-    window['ga'] = mockGa;
+    // Need to mock as we don't have window.ga.getAll()
+    const mockGetAll = mockControl.createFunctionMock('getAll');
+    const mockCreate = mockControl.createFunctionMock('create');
+    mockGetAll().$returns([]).$anyTimes();
+    // Creates 2 trackers (because of codelab gaid attribute).
+    mockCreate().$times(2);
+
+    window['ga'] = (...args) => {
+      window['ga'][args[0]]();
+    };
+    window['ga']['getAll'] = mockGetAll;
+    window['ga']['create'] = mockCreate;
+
     mockControl.$replayAll();
 
     document.body.appendChild(analytics);

--- a/google-codelab-analytics/google_codelab_analytics_test.js
+++ b/google-codelab-analytics/google_codelab_analytics_test.js
@@ -48,7 +48,10 @@ testSuite({
   testGAIDAttr_InitsTracker() {
     const mockGa = mockControl.createFunctionMock('ga');
     const analytics = new CodelabAnalytics();
+    // const mockInitGA = mockControl.createMethodMock(analytics, 'initGAScript_');
     analytics.setAttribute('gaid', 'UA-123');
+    // mockInitGA().$returns(Promise.resolve()).$once();
+    mockGa('getAll').$returns([]).$once();
     mockGa('create', 'UA-123', 'auto').$once();
     window['ga'] = mockGa;
     mockControl.$replayAll();
@@ -62,7 +65,9 @@ testSuite({
     analytics.setAttribute('gaid', 'UA-123');
     const locationSearchSaved = location.search;
     location.search = '?viewga=testView&param2=hi';
+    mockGa('getAll').$returns([]).$once();
     mockGa('create', 'UA-123', 'auto').$once();
+    mockGa('getAll').$returns([]).$once();
     mockGa('create', 'testView', 'auto', 'view').$once();
     window['ga'] = mockGa;
     mockControl.$replayAll();
@@ -77,7 +82,9 @@ testSuite({
     const mockGa = mockControl.createFunctionMock('ga');
     const analytics = new CodelabAnalytics();
     analytics.setAttribute('gaid', 'UA-123');
+    mockGa('getAll').$returns([]).$once();
     mockGa('create', 'UA-123', 'auto').$once();
+    mockGa('getAll').$returns([]).$once();
     mockGa('create', 'UA-456', 'auto', 'codelabAccount').$once();
     window['ga'] = mockGa;
     mockControl.$replayAll();

--- a/google-codelab-analytics/google_codelab_analytics_test.js
+++ b/google-codelab-analytics/google_codelab_analytics_test.js
@@ -1,0 +1,101 @@
+/**
+ * @license
+ * Copyright 2018 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+goog.module('googlecodelabs.CodelabAnalyticsTest');
+goog.setTestOnly();
+
+const CodelabAnalytics = goog.require('googlecodelabs.CodelabAnalytics');
+const MockControl = goog.require('goog.testing.MockControl');
+const dom = goog.require('goog.dom');
+const testSuite = goog.require('goog.testing.testSuite');
+goog.require('goog.testing.asserts');
+goog.require('goog.testing.jsunit');
+
+let mockControl;
+/**
+ * Noop the inject function, we don't need to be going to the actual network
+ * in tests
+ */
+CodelabAnalytics.injectGAscript = () => {};
+
+testSuite({
+
+  setUp() {
+    mockControl = new MockControl();
+  },
+
+  tearDown() {
+    dom.removeNode(document.body.querySelector('google-codelab-analytics'));
+
+    mockControl.$resetAll();
+    mockControl.$tearDown();
+  },
+
+  testGAIDAttr_InitsTracker() {
+    const mockGa = mockControl.createFunctionMock('ga');
+    const analytics = new CodelabAnalytics();
+    analytics.setAttribute('gaid', 'UA-123');
+    mockGa('create', 'UA-123', 'auto').$once();
+    window['ga'] = mockGa;
+    mockControl.$replayAll();
+    document.body.appendChild(analytics);
+    mockControl.$verifyAll();
+  },
+
+  testViewParam_InitsViewTracker() {
+    const mockGa = mockControl.createFunctionMock('ga');
+    const analytics = new CodelabAnalytics();
+    analytics.setAttribute('gaid', 'UA-123');
+    const locationSearchSaved = location.search;
+    location.search = '?viewga=testView&param2=hi';
+    mockGa('create', 'UA-123', 'auto').$once();
+    mockGa('create', 'testView', 'auto', 'view').$once();
+    window['ga'] = mockGa;
+    mockControl.$replayAll();
+
+    document.body.appendChild(analytics);
+
+    mockControl.$verifyAll();
+    location.search = locationSearchSaved;
+  },
+
+  testCodelabGAIDAttr_InitsCodelabTracker() {
+    const mockGa = mockControl.createFunctionMock('ga');
+    const analytics = new CodelabAnalytics();
+    analytics.setAttribute('gaid', 'UA-123');
+    mockGa('create', 'UA-123', 'auto').$once();
+    mockGa('create', 'UA-456', 'auto', 'codelabAccount').$once();
+    window['ga'] = mockGa;
+    mockControl.$replayAll();
+
+    document.body.appendChild(analytics);
+    analytics.setAttribute('codelab-gaid', 'UA-456');
+    mockControl.$verifyAll();
+  },
+
+  testPageviewEventDispatch_SendsPageViewTracking() {
+
+  },
+
+  testEventDispatch_SendsEventTracking() {
+
+  },
+
+  testCodelabAttributes_UpdatesTrackingParams() {
+
+  }
+});

--- a/google-codelab-survey/google_codelab_survey.js
+++ b/google-codelab-survey/google_codelab_survey.js
@@ -140,6 +140,14 @@ class CodelabSurvey extends HTMLElement {
       this.storedData_[this.surveyName_][question] = answer;
       this.storage_.set(
         this.storageKey_, JSON.stringify(this.storedData_[this.surveyName_]));
+      const event = new CustomEvent('google-codelab-action', {
+        detail: {
+          'category': 'survey',
+          'action': question.substring(0, 500),
+          'label': answer.substring(0, 500)
+        }
+      });
+      document.body.dispatchEvent(event);
     }
   }
 

--- a/google-codelab-survey/google_codelab_survey.scss
+++ b/google-codelab-survey/google_codelab_survey.scss
@@ -56,7 +56,7 @@ google-codelab-survey .option-text {
 
 .custom-radio-button {
   position: absolute;
-  top: 1px;
+  top: 5px;
   left: 0;
   height: 13px;
   width: 13px;
@@ -76,8 +76,8 @@ google-codelab-survey .option-text {
 }
 
 .survey-option-wrapper .custom-radio-button:after {
-  top: 3px;
-  left: 3px;
+  top: 1px;
+  left: 1px;
   width: 7px;
   height: 7px;
   border-radius: 50%;

--- a/google-codelab/google_codelab.js
+++ b/google-codelab/google_codelab.js
@@ -1,13 +1,13 @@
 /**
  * @license
  * Copyright 2018 Google Inc.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -27,7 +27,7 @@ const dom = goog.require('goog.dom');
 const events = goog.require('goog.events');
 const soy = goog.require('goog.soy');
 
-/** 
+/**
  * Deprecated. Title causes the bowser to display a tooltip over the whole codelab.
  * Use codelab-title instead.
  * @const {string}
@@ -86,20 +86,32 @@ const ANIMATION_DURATION = .5;
 const DRAWER_OPEN_ATTR = 'drawer--open';
 
 /**
- * Fired when the codelab steps have been fully initialized.
+ * The general codelab action event fired for trackable interactions.
  */
-const CODELAB_READY_EVENT = 'google-codelab-ready';
+const CODELAB_ACTION_EVENT = 'google-codelab-action';
 
 /**
- * Fired when user advances a codelab step or goes backwards.
+ * The event category detail for any codelab action event fired.
+ */
+const CODELAB_CUSTOM_EVENT_CATEGORY = 'Codelab Custom Event';
+
+/**
+ * The event action detail for when the codelab steps have been fully
+ * initialized.
+ */
+const CODELAB_READY_EVENT_ID = 'google-codelab-ready';
+
+/**
+ * The event action detail for when user advances a codelab step or goes
+ * backwards.
  * detail {{index: Number}}
  */
-const CODELAB_STEP_EVENT = 'google-codelab-step';
+const CODELAB_STEP_EVENT_ID = 'google-codelab-step';
 
 /**
- * Fired when user reaches the last step of the codelab.
+ * The event action detail for when user reaches the last step of the codelab.
  */
-const CODELAB_COMPLETE_EVENT = 'google-codelab-complete';
+const CODELAB_COMPLETE_EVENT_ID = 'google-codelab-complete';
 
 /**
  * @extends {HTMLElement}
@@ -178,7 +190,10 @@ class Codelab extends HTMLElement {
 
     window.requestAnimationFrame(() => {
       document.body.removeAttribute('unresolved');
-      this.fireEvent_(CODELAB_READY_EVENT);
+      this.fireEvent_(CODELAB_ACTION_EVENT, {
+        'category': CODELAB_CUSTOM_EVENT_CATEGORY,
+        'action': CODELAB_READY_EVENT_ID
+      });
     });
 
     if (this.resumed_) {
@@ -254,7 +269,7 @@ class Codelab extends HTMLElement {
 
   /**
    * @export
-   * @param {number} index 
+   * @param {number} index
    */
   select(index) {
     this.setAttribute(SELECTED_ATTR, index);
@@ -347,8 +362,8 @@ class Codelab extends HTMLElement {
   }
 
   /**
-   * 
-   * @param {!events.BrowserEvent} e 
+   *
+   * @param {!events.BrowserEvent} e
    */
   handleDrawerKeyDown_(e) {
     if (!this.drawer_) {
@@ -383,8 +398,8 @@ class Codelab extends HTMLElement {
   }
 
   /**
-   * 
-   * @param {!events.BrowserEvent} e 
+   *
+   * @param {!events.BrowserEvent} e
    */
   handleKeyDown_(e) {
     if (e.keyCode == KeyCodes.LEFT) {
@@ -526,8 +541,10 @@ class Codelab extends HTMLElement {
       return;
     }
 
-    this.fireEvent_(CODELAB_STEP_EVENT, {
-      index: selected
+    this.fireEvent_(CODELAB_ACTION_EVENT, {
+      'category': CODELAB_CUSTOM_EVENT_CATEGORY,
+      'action': CODELAB_STEP_EVENT_ID,
+      'label': selected
     });
 
     if (this.currentSelectedStep_ === -1) {
@@ -606,7 +623,10 @@ class Codelab extends HTMLElement {
       if (selected === this.steps_.length - 1) {
         this.nextStepBtn_.setAttribute(HIDDEN_ATTR, '');
         this.doneBtn_.removeAttribute(HIDDEN_ATTR);
-        this.fireEvent_(CODELAB_COMPLETE_EVENT);
+        this.fireEvent_(CODELAB_ACTION_EVENT, {
+          'category': CODELAB_CUSTOM_EVENT_CATEGORY,
+          'action': CODELAB_COMPLETE_EVENT_ID,
+        });
       } else {
         this.nextStepBtn_.removeAttribute(HIDDEN_ATTR);
         this.doneBtn_.setAttribute(HIDDEN_ATTR, '');
@@ -670,13 +690,15 @@ class Codelab extends HTMLElement {
   }
 
   /**
-   * 
-   * @param {string} eventName 
-   * @param {!Object=} detail 
+   *
+   * @param {string} eventName
+   * @param {!Object=} detail
    */
   fireEvent_(eventName, detail={}) {
-    const event = new CustomEvent(eventName, detail);
-    this.dispatchEvent(event);
+    const event = new CustomEvent(eventName, {
+      detail: detail
+    });
+    document.body.dispatchEvent(event);
   }
 
   /**
@@ -688,7 +710,7 @@ class Codelab extends HTMLElement {
     soy.renderElement(this, Templates.structure, {
       homeUrl: this.getHomeUrl_()
     });
-    
+
     this.drawer_ = this.querySelector('#drawer');
     this.titleContainer_ = this.querySelector('#codelab-title');
     this.stepsContainer_ = this.querySelector('#steps');

--- a/google-codelab/index.html
+++ b/google-codelab/index.html
@@ -21,6 +21,7 @@ the License.
   <link rel="stylesheet" href="//fonts.googleapis.com/css?family=Source+Code+Pro:400|Roboto:400,300,400italic,500,700|Roboto+Mono">
   <link rel="stylesheet" href="//fonts.googleapis.com/icon?family=Material+Icons">
   <link rel="stylesheet" href="/google-codelab-step/google_codelab_step_scss_bin.css">
+  <link rel="stylesheet" href="/google-codelab-survey/google_codelab_survey_scss_bin.css">
   <link rel="stylesheet" href="google_codelab_scss_bin.css">
   <style>
     body {
@@ -37,8 +38,8 @@ the License.
 </head>
 
 <body unresolved>
-  <google-codelab-analytics></google-codelab-analytics>
-  <google-codelab id="accelerated-mobile-pages-advanced" title="Accelerated Mobile Pages Advanced Concepts" environment="web" feedback-link="mailto:tomgreenaway@google.com">
+  <google-codelab-analytics gaid="UA-49880327-14"></google-codelab-analytics>
+  <google-codelab codelab-gaid="UA-49880327-15" id="accelerated-mobile-pages-advanced" title="Accelerated Mobile Pages Advanced Concepts" environment="web" feedback-link="mailto:tomgreenaway@google.com">
     <google-codelab-step label="Overview" duration="1">
       <p>This codelab is a continuation of the concepts introduced in Accelerated Mobile Pages Foundations. You should already
         have completed the previous code lab before starting this lab or at least have a basic understanding AMP&#39;s core
@@ -935,15 +936,32 @@ ga(&#39;send&#39;, &#39;pageview&#39;);
         </li>
       </ul>
 
+      <google-codelab-survey survey-id="polymer-maps-1">
+        <h4>How would rate your experience with Polymer?</h4>
+        <paper-radio-group>
+          <paper-radio-button>Novice</paper-radio-button>
+          <paper-radio-button>Intermediate</paper-radio-button>
+          <paper-radio-button>Advanced</paper-radio-button>
+        </paper-radio-group>
+
+        <h4>How will you use use this tutorial?</h4>
+        <paper-radio-group>
+          <paper-radio-button>I won't</paper-radio-button>
+          <paper-radio-button>Complete it</paper-radio-button>
+        </paper-radio-group>
+      </google-codelab-survey>
+
 
     </google-codelab-step>
 
   </google-codelab>
+  <script async="" src="https://www.google-analytics.com/analytics.js"></script>
   <script src="/external/polyfill/src/native-shim.js"></script>
   <script src="/external/polyfill/custom-elements.min.js"></script>
   <script src="/external/prettify/src/prettify.js"></script>
   <script src="/google-codelab-analytics/google_codelab_analytics_bin.js"></script>
   <script src="/google-codelab-step/google_codelab_step_bin.js"></script>
+  <script src="/google-codelab-survey/google_codelab_survey_bin.js"></script>
   <script src="/google-codelab/google_codelab_bin.js"></script>
 </body>
 

--- a/google-codelab/index.html
+++ b/google-codelab/index.html
@@ -955,7 +955,6 @@ ga(&#39;send&#39;, &#39;pageview&#39;);
     </google-codelab-step>
 
   </google-codelab>
-  <script async="" src="https://www.google-analytics.com/analytics.js"></script>
   <script src="/external/polyfill/src/native-shim.js"></script>
   <script src="/external/polyfill/custom-elements.min.js"></script>
   <script src="/external/prettify/src/prettify.js"></script>

--- a/google-codelab/index.html
+++ b/google-codelab/index.html
@@ -37,6 +37,7 @@ the License.
 </head>
 
 <body unresolved>
+  <google-codelab-analytics></google-codelab-analytics>
   <google-codelab id="accelerated-mobile-pages-advanced" title="Accelerated Mobile Pages Advanced Concepts" environment="web" feedback-link="mailto:tomgreenaway@google.com">
     <google-codelab-step label="Overview" duration="1">
       <p>This codelab is a continuation of the concepts introduced in Accelerated Mobile Pages Foundations. You should already
@@ -611,7 +612,7 @@ the License.
         <code>autoplay</code> attribute to the page and the delay attribute with a value of 2000 like so:
         <code>delay=&#34;2000&#34;</code>.</p>
       <p>Your final result should look something like this:</p>
-      <pre><code>&lt;amp-carousel layout=&#34;responsive&#34; width=&#34;300&#34; height=&#34;168&#34; 
+      <pre><code>&lt;amp-carousel layout=&#34;responsive&#34; width=&#34;300&#34; height=&#34;168&#34;
          type=&#34;slides&#34; autoplay delay=&#34;2000&#34; loop&gt;
   &lt;amp-img src=&#34;mountains-1.jpg&#34; width=&#34;300&#34; height=&#34;168&#34; layout=&#34;responsive&#34;&gt;&lt;/amp-img&gt;
   &lt;amp-img src=&#34;mountains-2.jpg&#34; width=&#34;300&#34; height=&#34;168&#34; layout=&#34;responsive&#34;&gt;&lt;/amp-img&gt;
@@ -941,6 +942,7 @@ ga(&#39;send&#39;, &#39;pageview&#39;);
   <script src="/external/polyfill/src/native-shim.js"></script>
   <script src="/external/polyfill/custom-elements.min.js"></script>
   <script src="/external/prettify/src/prettify.js"></script>
+  <script src="/google-codelab-analytics/google_codelab_analytics_bin.js"></script>
   <script src="/google-codelab-step/google_codelab_step_bin.js"></script>
   <script src="/google-codelab/google_codelab_bin.js"></script>
 </body>

--- a/tools/BUILD.bazel
+++ b/tools/BUILD.bazel
@@ -32,6 +32,7 @@ go_binary(
         "//demo:hello_bin",
         "//demo:hello_test",
         "//google-codelab:google_codelab_files",
+        "//google-codelab-analytics:google_codelab_analytics_files",
         "//google-codelab-index:google_codelab_index_files",
         "//google-codelab-step:google_codelab_step_files",
         "//google-codelab-survey:google_codelab_survey_files",


### PR DESCRIPTION
Adds analytics custom element. This would require an update to the codelab template in Claat, but I think it's the right move. If we don't want to inject the analytics script + create the trackers in the custom element then I can remove that functionality.