### PR TITLE
Use image native width unless set

### DIFF
--- a/google-codelab-step/google_codelab_step.scss
+++ b/google-codelab-step/google_codelab_step.scss
@@ -219,6 +219,7 @@ google-codelab-step .instructions iron-icon {
 }
 
 google-codelab-step .instructions img {
+  max-width: 100%;
   vertical-align: bottom;
 }
 


### PR DESCRIPTION
If an image does not have a defined width it is currently forced
to be 100% this can cause codelabs initially written in markdown
to have stretched images since there is no way to define image
size in markdown. From GDocs image width is automatically added.

This change allows both markdown and GDoc authors to get what
they expect when they publish a codelab from the corresponding
source.