### PR TITLE
Fix null category on 'event' type analytics events.

### DIFF
--- a/google-codelab-analytics/google_codelab_analytics.js
+++ b/google-codelab-analytics/google_codelab_analytics.js
@@ -148,14 +148,15 @@ class CodelabAnalytics extends HTMLElement {
           e.getBrowserEvent().detail);
         // Add tracking...
         this.trackEvent_(
-          detail.category, detail.action, detail.label, detail.value);
+          detail['category'], detail['action'], detail['label'],
+          detail['value']);
       });
 
     this.pageviewEventHandler_.listen(document.body, PAGEVIEW_EVENT,
       (e) => {
         const detail = /** @type {AnalyticsPageview} */ (
           e.getBrowserEvent().detail);
-        this.trackPageview_(detail.page, detail.title);
+        this.trackPageview_(detail['page'], detail['title']);
       });
   }
 


### PR DESCRIPTION
I noticed this when checking the analytics element for parity with the existing analytics component. 

All of the properties other than "category" were not being obfuscated, but I think this was just a happy coincidence - according to some research I did, if the closure compiler doesn't recognize an object's type, it will avoid obfuscating anything that appears as a property in any externs file. "action", "label", "value", "page", and "title" are all extern properties of *something*, so they weren't obfuscated. But "category" is not, so it was obfuscated. I quoted the others as well to be safe - if those externs happen to change (unlikely as it is), we would break.