### PR TITLE
Resolves race conditions with analytics event firing. Fixes #59.

### DIFF
--- a/google-codelab-analytics/google_codelab_analytics.js
+++ b/google-codelab-analytics/google_codelab_analytics.js
@@ -50,6 +50,15 @@ const CODELAB_ENV_ATTR = 'environment';
 /** @const {string} */
 const CODELAB_CATEGORY_ATTR = 'category';
 
+/** @const {string} */
+const ANALYTICS_READY_ATTR = 'anayltics-ready';
+
+/**
+ * A list of selectors whose elements are waiting for this to be set up.
+ * @const Array<string>
+ */
+const DEPENDENT_SELECTORS = ['google-codelab'];
+
 
 /**
  * Event detail passed when firing ACTION_EVENT.
@@ -135,8 +144,8 @@ class CodelabAnalytics extends HTMLElement {
   /** @private */
   init_() {
     this.createTrackers_();
-    this.trackPageview_();
     this.addEventListeners_();
+    this.setAnalyticsReadyAttrs_();
     this.hasSetup_ = true;
   }
 
@@ -230,6 +239,17 @@ class CodelabAnalytics extends HTMLElement {
       'title': opt_title || ''
     };
     this.gaSend_(params);
+  }
+
+  /**
+   * Sets analytics ready attributes on dependent elements.
+   */
+  setAnalyticsReadyAttrs_() {
+    DEPENDENT_SELECTORS.forEach((selector) => {
+      document.querySelectorAll(selector).forEach((element) => {
+        element.setAttribute(ANALYTICS_READY_ATTR, ANALYTICS_READY_ATTR);
+      });
+    });
   }
 
   /** @private */


### PR DESCRIPTION
This fixes 2 race conditions:

1. The issue described in #58, where we were trying to fire an event with the title from a state where we didn't know what the title was. This was resolved by storing the title in a class property each time it changes.
1. A race condition with the google-codelabs-analytics ACTION_EVENT and PAGEVIEW_EVENT listeners - google-codelabs was firing events that google-codelabs-analytics was supposed to be listening to, but before it had set up its listeners. google-codelabs now defers firing those events until it knows that analytics is listening for them, via the analytics-ready property.

@arkassay, can you confirm that removing the call to `this.trackPageview_();` in google-codelabs-analytics' `init()` is ok? We're already tracking the page view in google-codelabs, and this was ultimately tracking a pageview with no title or page URL.