### PR TITLE
Add deprecation notification.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
+# DEPRECATED
+This repository is deprecated - make needed changes to codelab-elements code in
+[googlecodelabs/tools/codelab-elements](https://github.com/googlecodelabs/tools/tree/master/codelab-elements).
+
 # Codelab Custom Elements
 
 The next generation of the codelab elements without any framework or library


### PR DESCRIPTION
Modifies the README to indicate that this repo is deprecated, and points users to the codelab-elements folder in googlecodelabs/tools.